### PR TITLE
fix: exclude vendored SQLite headers from clang-format and fix QUERY_VARS type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,14 @@ demo-db: build/muninn$(EXT)                    ## Build the KG demo database for
 
 format: format-c format-python format-js       ## Format all code
 
+# C files for formatting/linting — excludes vendored SQLite headers not authored here.
+# .clang-format-ignore is only supported by clang-format ≥ 18; Ubuntu 22.04 ships 14.
+CLANG_FORMAT_SRCS = $(wildcard src/*.c) $(wildcard test/*.c)
+CLANG_FORMAT_HDRS = $(filter-out src/sqlite3.h src/sqlite3ext.h, $(wildcard src/*.h)) $(wildcard test/*.h)
+CLANG_FORMAT_FILES = $(CLANG_FORMAT_SRCS) $(CLANG_FORMAT_HDRS)
+
 format-c:                                      ## Format C code with clang-format
-	clang-format -i src/*.c src/*.h test/*.c test/*.h
+	clang-format -i $(CLANG_FORMAT_FILES)
 
 init-python: .venv/.init-python                       ## Set up Python virtual environment and install dependencies
 .venv/.init-python: pyproject.toml
@@ -174,7 +180,7 @@ lint: lint-c lint-python lint-js format               ## Lint all code
 
 lint-c:                                        ## Lint C code with clang-format (check mode)
 	@if command -v clang-format >/dev/null 2>&1; then \
-		clang-format --dry-run --Werror src/*.c src/*.h test/*.c test/*.h 2>/dev/null; \
+		clang-format --dry-run --Werror $(CLANG_FORMAT_FILES) 2>/dev/null; \
 		echo "C lint passed"; \
 	else \
 		echo "clang-format not installed — skipping C lint"; \

--- a/scripts/generate_build.py
+++ b/scripts/generate_build.py
@@ -23,6 +23,7 @@ import json
 import logging
 import re
 import shutil
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -257,23 +258,23 @@ def _llama_lib_paths() -> list[str]:
 
 # Each entry: variable name → lambda returning its space-separated string value.
 # Makefile evaluates these via: VAR := $(shell python3 scripts/generate_build.py query VAR)
-QUERY_VARS: dict[str, callable] = {
+QUERY_VARS: dict[str, Callable[[], str]] = {
     # File lists
-    "SRC":                    lambda: " ".join(SOURCES),
-    "HEADERS":                lambda: " ".join(HEADERS),
-    "TEST_SRC":               lambda: " ".join(TEST_SOURCES),
-    "TEST_LINK_SRC":          lambda: " ".join(TEST_LINK_SOURCES),
+    "SRC": lambda: " ".join(SOURCES),
+    "HEADERS": lambda: " ".join(HEADERS),
+    "TEST_SRC": lambda: " ".join(TEST_SOURCES),
+    "TEST_LINK_SRC": lambda: " ".join(TEST_LINK_SOURCES),
     # WASM file lists (prefixed with ../ for wasm/ subdirectory)
-    "MUNINN_SRC_WASM":        lambda: " ".join(f"../{s}" for s in SOURCES),
-    "MUNINN_SRC_WASM_LITE":   lambda: " ".join(f"../{s}" for s in SOURCES_WASM_LITE),
-    "SOURCES_WASM_EXTRA":     lambda: " ".join(f"../{s}" for s in SOURCES_WASM_EXTRA),
+    "MUNINN_SRC_WASM": lambda: " ".join(f"../{s}" for s in SOURCES),
+    "MUNINN_SRC_WASM_LITE": lambda: " ".join(f"../{s}" for s in SOURCES_WASM_LITE),
+    "SOURCES_WASM_EXTRA": lambda: " ".join(f"../{s}" for s in SOURCES_WASM_EXTRA),
     # CMake flags
-    "LLAMA_CMAKE_FLAGS":      lambda: _cmake_flags_str(CMAKE_FLAGS_BASE),
+    "LLAMA_CMAKE_FLAGS": lambda: _cmake_flags_str(CMAKE_FLAGS_BASE),
     "LLAMA_CMAKE_FLAGS_WASM": lambda: _cmake_flags_str(CMAKE_FLAGS_WASM),
     # llama.cpp paths
-    "LLAMA_INCLUDE":          lambda: " ".join(f"-I{d}" for d in LLAMA_INCLUDE_DIRS),
-    "LLAMA_INCLUDE_WASM":     lambda: " ".join(f"-I../{d}" for d in LLAMA_INCLUDE_DIRS),
-    "LLAMA_LIBS_CORE":        lambda: " ".join(_llama_lib_paths()),
+    "LLAMA_INCLUDE": lambda: " ".join(f"-I{d}" for d in LLAMA_INCLUDE_DIRS),
+    "LLAMA_INCLUDE_WASM": lambda: " ".join(f"-I../{d}" for d in LLAMA_INCLUDE_DIRS),
+    "LLAMA_LIBS_CORE": lambda: " ".join(_llama_lib_paths()),
 }
 
 


### PR DESCRIPTION
Fixes #2

**Root causes fixed:**

1. `make lint-c` was including vendored `src/sqlite3.h` and `src/sqlite3ext.h` in the clang-format check. The `.clang-format-ignore` file requires clang-format ≥ 18, but Ubuntu 22.04 ships version 14. Makefile now uses explicit `$(filter-out ...)` to exclude these files unconditionally.

2. `ruff format --check .` was failing on alignment padding in the `QUERY_VARS` dict in `scripts/generate_build.py`. Also fixed the invalid `callable` type annotation to use `Callable[[], str]` from `collections.abc`.

Generated with [Claude Code](https://claude.ai/code)